### PR TITLE
Add support for Android UI tests

### DIFF
--- a/plugin/src/main/kotlin/com/karumi/kotlinsnapshot/plugin/KotlinSnapshotPlugin.kt
+++ b/plugin/src/main/kotlin/com/karumi/kotlinsnapshot/plugin/KotlinSnapshotPlugin.kt
@@ -33,6 +33,7 @@ open class KotlinSnapshotPlugin : Plugin<Project> {
                 val dependency = project.dependencies
                     .create("com.karumi.kotlinsnapshot:core:2.2.0")
                 project.dependencies.add("testImplementation", dependency)
+                project.dependencies.add("androidTestImplementation", dependency)
                 project.gradle.removeListener(this)
             }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/Karumi/KotlinSnapshot/issues/57

### :tophat: What is the goal?
Add support to Android UI Tests

### :memo: How is it being implemented?
Automatically add project dependency for `androidTestImplementation` for this plugin

### :boom: How can it be tested?
Create a new test under `androidTest` and reference `KotlinSnapshot`

_If it cannot be tested explain why._

- [ ] **Use case 1:** Release a new SNAPSHOT version of the library and pull it into an project that has `androidTest` source